### PR TITLE
Replacing fzf with telescope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # My Dotfiles
 These are my dotfiles for nvim, bash and tmux.
 
+##Requirements
+ - Neovim Nightly (0.5+)
+
 ## Installation
 The installation for these relies on symlinks, I shall list the required ones below
  - `~/.config/nvim/init.vim` -> `nvim/init.vim`

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -16,6 +16,7 @@ Plug 'nvim-lua/popup.nvim'
 Plug 'nvim-lua/plenary.nvim'
 Plug 'nvim-telescope/telescope.nvim'
 Plug 'fannheyward/telescope-coc.nvim'
+Plug 'nvim-telescope/telescope-github.nvim'
 Plug 'numkil/ag.nvim'
 call plug#end()
 
@@ -165,7 +166,11 @@ nnoremap <leader>fh <cmd>Telescope help_tags<CR>
 command! TODO :Ag TODO
 lua << EOF
 require('telescope').load_extension('coc')
+require('telescope').load_extension('gh')
 EOF
+
+command! Gissues Telescope gh issues
+command! GPR Telescope gh pull_request
 
 """"""""""""""""""""""""""""""
 "       EASYALIGN            "

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -7,7 +7,6 @@ Plug 'tpope/vim-surround'
 Plug 'gruvbox-community/gruvbox'
 Plug 'tpope/vim-fugitive'
 Plug 'vim-syntastic/syntastic'
-Plug 'junegunn/fzf', {'do':{-> fzf#install() } } | Plug 'junegunn/fzf.vim'
 Plug 'junegunn/vim-easy-align'
 Plug 'wincent/scalpel'
 Plug 'preservim/nerdcommenter'
@@ -152,19 +151,6 @@ endfunction
 let g:vimtex_compiler_progname='nvr'
 let g:vimtex_fold_enabled=1
 let g:vimtex_indent_on_ampersands=0
-
-
-""""""""""""""""""""""""""""""
-"            FZF             "
-""""""""""""""""""""""""""""""
-"" Use <C-p> to find a file in the project using fzf
-"nnoremap <C-p> :Files<CR>
-"" Use P to find text in the current file
-"nnoremap <leader>p :Rg<CR>
-"let $FZF_DEFAULT_COMMAND="find . -not -path \"*/.git/*\"" " Include dotfiles but not any files inside a .git folder
-
-"" Command to easily find TODO's in project
-"command! TODO Rg TODO
 
 
 """"""""""""""""""""""""""""""

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -165,6 +165,11 @@ nnoremap <A-p> <cmd>Telescope live_grep<CR>
 nnoremap <leader>fh <cmd>Telescope help_tags<CR>
 command! TODO :Ag TODO
 lua << EOF
+require('telescope').setup{
+	defaults={
+		initial_mode="normal"
+	}
+}
 require('telescope').load_extension('coc')
 require('telescope').load_extension('gh')
 EOF

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -157,22 +157,22 @@ let g:vimtex_indent_on_ampersands=0
 """"""""""""""""""""""""""""""
 "            FZF             "
 """"""""""""""""""""""""""""""
-" Use <C-p> to find a file in the project using fzf
-nnoremap <C-p> :Files<CR>
-" Use P to find text in the current file
-nnoremap <leader>p :Rg<CR>
-let $FZF_DEFAULT_COMMAND="find . -not -path \"*/.git/*\"" " Include dotfiles but not any files inside a .git folder
+"" Use <C-p> to find a file in the project using fzf
+"nnoremap <C-p> :Files<CR>
+"" Use P to find text in the current file
+"nnoremap <leader>p :Rg<CR>
+"let $FZF_DEFAULT_COMMAND="find . -not -path \"*/.git/*\"" " Include dotfiles but not any files inside a .git folder
 
-" Command to easily find TODO's in project
-command! TODO Rg TODO
+"" Command to easily find TODO's in project
+"command! TODO Rg TODO
 
 
 """"""""""""""""""""""""""""""
 "         TELESCOPE          "
 """"""""""""""""""""""""""""""
-nnoremap <leader>ff <cmd>Telescope find_files<CR>
-nnoremap <leader>fg <cmd>Telescope live_grep<CR>
-nnoremap <leader>fb <cmd>Telescope buffers<CR>
+nnoremap <C-p> <cmd>Telescope git_files<CR>
+nnoremap g<C-p> <cmd>Telescope find_files hidden=true<CR>
+nnoremap <A-p> <cmd>Telescope live_grep<CR>
 nnoremap <leader>fh <cmd>Telescope help_tags<CR>
 
 

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -15,6 +15,7 @@ Plug 'thaerkh/vim-workspace'
 Plug 'nvim-lua/popup.nvim'
 Plug 'nvim-lua/plenary.nvim'
 Plug 'nvim-telescope/telescope.nvim'
+Plug 'fannheyward/telescope-coc.nvim'
 Plug 'numkil/ag.nvim'
 call plug#end()
 
@@ -162,6 +163,9 @@ nnoremap g<C-p> <cmd>Telescope find_files hidden=true<CR>
 nnoremap <A-p> <cmd>Telescope live_grep<CR>
 nnoremap <leader>fh <cmd>Telescope help_tags<CR>
 command! TODO :Ag TODO
+lua << EOF
+require('telescope').load_extension('coc')
+EOF
 
 """"""""""""""""""""""""""""""
 "       EASYALIGN            "

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -168,6 +168,15 @@ command! TODO Rg TODO
 
 
 """"""""""""""""""""""""""""""
+"         TELESCOPE          "
+""""""""""""""""""""""""""""""
+nnoremap <leader>ff <cmd>Telescope find_files<CR>
+nnoremap <leader>fg <cmd>Telescope live_grep<CR>
+nnoremap <leader>fb <cmd>Telescope buffers<CR>
+nnoremap <leader>fh <cmd>Telescope help_tags<CR>
+
+
+""""""""""""""""""""""""""""""
 "       EASYALIGN            "
 """"""""""""""""""""""""""""""
 " use ga to use EasyAlign plugin

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -12,6 +12,10 @@ Plug 'junegunn/vim-easy-align'
 Plug 'wincent/scalpel'
 Plug 'preservim/nerdcommenter'
 Plug 'thaerkh/vim-workspace'
+
+Plug 'nvim-lua/popup.nvim'
+Plug 'nvim-lua/plenary.nvim'
+Plug 'nvim-telescope/telescope.nvim'
 call plug#end()
 
 set termguicolors

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -15,6 +15,7 @@ Plug 'thaerkh/vim-workspace'
 Plug 'nvim-lua/popup.nvim'
 Plug 'nvim-lua/plenary.nvim'
 Plug 'nvim-telescope/telescope.nvim'
+Plug 'numkil/ag.nvim'
 call plug#end()
 
 set termguicolors
@@ -160,7 +161,7 @@ nnoremap <C-p> <cmd>Telescope git_files<CR>
 nnoremap g<C-p> <cmd>Telescope find_files hidden=true<CR>
 nnoremap <A-p> <cmd>Telescope live_grep<CR>
 nnoremap <leader>fh <cmd>Telescope help_tags<CR>
-
+command! TODO :Ag TODO
 
 """"""""""""""""""""""""""""""
 "       EASYALIGN            "


### PR DESCRIPTION
Replaced fzf with telescope. Now requires neovim nightly (0.5+).

Most commands have remained the same, the following are changes or new commands
## Inbuilt telescope commands
- `<A-p>` can be used to search for text in the pwd
- `<C-p>` needs to be prefaced with a `g` if not in a git repo
- `<leader>fh` fuzzy searches for a help tag
## Telescope extensions
- `:Gissues` gives a fuzzy find window for github issues
- `:GPR` gives a fuzzy find window for github pull requests
- Coc telescope integration has been added but no maps made
